### PR TITLE
READMEにChatSpaceのDB設計を記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,53 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|mail|string|null: false|
+|password|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :groups, through: :groups_users
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- has_many :messages
+- has_many :users, through: :groups_users
+
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## massagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -1,27 +1,4 @@
-# README
-
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+# ChatSpaceのDB設計
 
 ## usersテーブル
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ### Association
 - has_many :messages
 - has_many :groups, through: :groups_users
+- has_many :groups_users
 
 
 ## groupsテーブル
@@ -23,7 +24,7 @@
 ### Association
 - has_many :messages
 - has_many :users, through: :groups_users
-
+- has_many :groups_users
 
 ## groups_usersテーブル
 


### PR DESCRIPTION
# What
READMEにChatSpaceのDBを記載。

# Why
ChatSpaceの実装に入る前にDBを設計し、正しく設計できているか確認してもらうため。