### PR TITLE
Create Automatic-updating-function

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     if ( message.image ) {
       var html =
-        `<div class="message">
+        `<div class="message" data-message-id=${message.id}>
           <div class="user-data">
             <div class="name">
               ${message.user_name}
@@ -21,7 +21,7 @@ $(function(){
       return html;
     } else {
       var html =
-       `<div class="message">
+       `<div class="message" data-message-id=${message.id}>
           <div class="user-data">
             <div class="name">
               ${message.user_name}
@@ -62,6 +62,32 @@ $(function(){
     .fail(function() {
       alert("メッセージ送信に失敗しました");
       $('.submit-btn').prop('disabled', false);
+    })
   })
-  })
+
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'GET',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .user-data
     .name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# what
ユーザーが閲覧しているチャットグループのチャットが自動更新される機能の実装。
0.7秒おきに自動的にチャット内容が更新され、グループ内のチャットが最新の状態になるようにしている。

# why
今までの実装内容では、自分は非同期通信により最新の情報が更新されているように見えるが、他のチャットグループのメンバーはリロードしないと最新の情報に更新されていなかった。いちいちページをリロードしなければならないという煩わしいことをしなくても他のメンバーの最新の投稿が閲覧できるようにすれば、このチャットアプリがより使いやすい、LINEのような快適なチャットアプリとなるため。

以下のGyazo Gifを見ていただければ、きちんと実装できていることが確認できると思います。
https://gyazo.com/51faace02ac61204918e245effc5b8b1